### PR TITLE
Add resynchronise option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This plugin enhaces the translation handling for [Kirby 2](http://getkirby.com) with the following features:
 
 + possibility to delete translations
++ possibility to resynchronize translations with the default language file
 + handle and display the translation status for pages in the panel
 
 ## Please notice
@@ -76,7 +77,7 @@ fields:
 
 ### Optional settings
 
-If you like, you can disable the checkbox (and with it the orange status) and/or the possibility to delete translations with the following setup.
+If you like, you can disable the checkbox (and with it the orange status) and/or the possibility to delete or update translations with the following setup.
 
 ```
 ...
@@ -84,6 +85,7 @@ fields:
   mytranslations:
     type: translations
     deletable: false
+    updatable: false
     uptodate: false
 ...
 ```

--- a/fields/translations/assets/css/translations.css
+++ b/fields/translations/assets/css/translations.css
@@ -66,22 +66,31 @@
 .field-translations-wrapper .delete,
 .field-translations-wrapper .translations-delete,
 .field-translations-wrapper .translations-delete-confirm,
-.field-translations-wrapper .untranslated.active .delete {
+.field-translations-wrapper .untranslated.active .delete,
+.field-translations-wrapper .update,
+.field-translations-wrapper .translations-update,
+.field-translations-wrapper .translations-update-confirm,
+.field-translations-wrapper .untranslated.active .update {
   display: none;
 }
 
 .field-translations-wrapper .active.translated .delete,
 .field-translations-wrapper .active.translated .delete i,
-.field-translations-wrapper .active.translated .translations-delete {
+.field-translations-wrapper .active.translated .translations-delete,
+.field-translations-wrapper .active.translated .update,
+.field-translations-wrapper .active.translated .update i,
+.field-translations-wrapper .active.translated .translations-update {
   display: inline;
   color: #777;
 }
 
-.field-translations-wrapper .active.translated.default .translations-delete {
+.field-translations-wrapper .active.translated.default .translations-delete, 
+.field-translations-wrapper .active.translated.default .translations-update {
   display: none;
 }
 
-.field-translations-wrapper .active .translations-delete-confirm {
+.field-translations-wrapper .active .translations-delete-confirm, 
+.field-translations-wrapper .active .translations-update-confirm {
   position: absolute;
   top: 0;
   right: 0;
@@ -93,16 +102,23 @@
   padding-top: 5px;
 }
 
-.field-translations-wrapper .active .translations-delete-confirm .btn {
+.field-translations-wrapper .active .translations-delete-confirm .btn, 
+.field-translations-wrapper .active .translations-update-confirm .btn {
   background: #efefef;
 }
 
-.field-translations-wrapper .active .translations-delete-confirm .btn:hover {
+.field-translations-wrapper .active .translations-delete-confirm .btn:hover, 
+.field-translations-wrapper .active .translations-update-confirm .btn:hover {
   background: black;
 }
 
-.field-translations-wrapper .active .translations-delete-confirm .btn-negative:hover {
+.field-translations-wrapper .active .translations-delete-confirm .btn-negative:hover, 
+.field-translations-wrapper .active .translations-update-confirm .btn-negative:hover {
   background: #b3000a;
+}
+
+.field-translations-wrapper .translations-update-alert {
+  margin-top: 5px;
 }
 
 .field-translations-wrapper label.input {

--- a/fields/translations/assets/js/translations.js
+++ b/fields/translations/assets/js/translations.js
@@ -11,4 +11,16 @@ $(function(){
     e.preventDefault();
     return false;
   });
+
+  $(document).on('click','.translations-update',function (e) {
+    $(this).next('.translations-update-confirm').fadeIn();
+    e.preventDefault();
+    return false;
+  });
+
+  $(document).on('click','.translations-update-cancel-btn',function (e) {
+    $(this).parent('.translations-update-confirm').fadeOut();
+    e.preventDefault();
+    return false;
+  });
 });

--- a/fields/translations/template.php
+++ b/fields/translations/template.php
@@ -6,6 +6,19 @@
         <i class="fa fa-<?php echo $field->statusIcon($language); ?>"></i>
       </a>
 
+	<?php if ($field->updatable): ?>
+		<span class="update">
+	          <a class="translations-update" href="#">
+	            <i class="fa fa-refresh"></i>
+	          </a>
+	          <span class="translations-update-confirm">
+	            <a class="translations-update-confirm-btn btn btn-rounded btn-submit btn-negative" href="<?php echo panel()->urls()->index() ?>/plugin.translations.update/<?php echo $language->code() ?>/<?php echo $page->id() ?>">Sync <?php echo str::upper($language->code()) ?> with <?php echo str::upper($site->defaultLanguage()->code()) ?></a>
+	            <a class="translations-update-cancel-btn btn btn-rounded btn-submit" href="#">Cancel</a>
+	            <p class="translations-update-alert">This will reset the file. All changes will be lost.</p>
+	          </span>
+	    </span>
+	<?php endif; ?>
+
       <?php if ($field->deletable): ?>
         <span class="delete">
           <a class="translations-delete" href="#">

--- a/fields/translations/translations.php
+++ b/fields/translations/translations.php
@@ -14,6 +14,7 @@ class translationsField extends CheckboxField {
   public function __construct() {
     $this->icon = false;
     $this->deletable = true;
+    $this->updatable = true;
     $this->uptodate = true;
   }
 

--- a/translations.php
+++ b/translations.php
@@ -28,6 +28,28 @@ if (class_exists('Panel') && site()->user() && site()->user()->hasPanelAccess())
         }
         panel()->redirect('pages/'. $id . '/edit');
       }
+    ),
+    array(
+      'pattern' => 'plugin.translations.update/(:any)/(:all)',
+      'action' => function($language, $id) {
+        $page = page($id);
+        $file = $page->textfile(NULL, $language);
+        $default = site()->defaultLanguage()->code();
+
+        if ($mainContent = f::read($page->textfile(NULL, $default))) {
+	        if (f::remove($file) && f::write($file, $mainContent)) {
+	        	var_dump($mainContent);
+	        	panel()->notify(strtoupper($language) . ' updated');
+	        }
+	        else {
+	          panel()->alert('Translation could not be updated');
+	        }
+        }
+        else {
+          panel()->alert('Translation could not be updated');
+        }
+        panel()->redirect('pages/'. $id . '/edit');
+      }
     )
   ));
 }

--- a/translations.php
+++ b/translations.php
@@ -37,8 +37,7 @@ if (class_exists('Panel') && site()->user() && site()->user()->hasPanelAccess())
         $default = site()->defaultLanguage()->code();
 
         if ($mainContent = f::read($page->textfile(NULL, $default))) {
-	        if (f::remove($file) && f::write($file, $mainContent)) {
-	        	var_dump($mainContent);
+	        if (f::write($file, $mainContent)) {
 	        	panel()->notify(strtoupper($language) . ' updated');
 	        }
 	        else {


### PR DESCRIPTION
Not sure it's the way to go, but I had trouble with dynamic fields (structure) and language deleting.

Let's say I have a structure field I'm filling on the default language page. I didn't pay attention but one of my secondary language file was already created. Now I don't want to re-create all the structure entries by hand, rather get a fresh start from the already-created ones.

If I delete the secondary language file in order to do so, it keeps the current file content cached somewhere and I'm not able to get the default content :

![delete](https://user-images.githubusercontent.com/14079751/29962522-c8165424-8f03-11e7-947c-f23a6f3fc190.gif)

I have to flush my browser data in order to be able to see it.

I have no clue where to find this cache and delete it, so I added a "resync" button that updates the file with the default language content :

![update](https://user-images.githubusercontent.com/14079751/29962595-068818f0-8f04-11e7-96b9-0cf1a334bdbc.gif)

(Nothing to do with the new delete method I already had this issue with the previous way of textfile deletion, the new one is working fine here 👍)